### PR TITLE
PBU-6306 neue Felder kontonummer und filialnummer an DarlehensdatenAnfrage

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -47,6 +47,16 @@ definitions:
       Eindeutige Nummer des Darlehens beim Produktanbieter, z.B. Darlehensnummer, Kontonummer oder IBAN.
       Kann Buchstaben, Zahlen oder andere Sonderzeichen enthalten.
 
+  Filialnummer:
+    type: string
+    description: |
+      fuer die Deutsche Bank und DSL relevant
+
+  Kontonummer:
+    type: string
+    description: |
+      fuer die Deutsche Bank und DSL relevant
+
   PartnerId:
     type: string
     description: |
@@ -173,6 +183,10 @@ definitions:
     properties:
       hauptkontonummer:
         $ref: '#/definitions/Hauptkontonummer'
+      filialnummer:
+        $ref: '#/definitions/Filialnummer'
+      kontonummer:
+        $ref: '#/definitions/kontonummer'
       bestehendeDarlehen:
         type: array
         items:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -186,7 +186,7 @@ definitions:
       filialnummer:
         $ref: '#/definitions/Filialnummer'
       kontonummer:
-        $ref: '#/definitions/kontonummer'
+        $ref: '#/definitions/Kontonummer'
       bestehendeDarlehen:
         type: array
         items:


### PR DESCRIPTION
- neue Felder kontonummer und filialnummer an DarlehensdatenAnfrage für Deutsche Bank und DSL Prolongationsanfrage
- Hintergrund: Darlehensdatenanfrage für Prolongation wird für die Deutsche Bank aktiviert. Im Frontend werden dafür zwei neue Felder kontonummer und filialnummer angezeigt. Die Darlehensdatenanfrage für die DSL wird analog zur Deutschen Bank angepasst.
- API wird vom ep2-dda-java-rest-client benötigt (https://github.com/hypoport/ep2-dda-java-rest-client)

Hinweis: in der Commit-Message steht fälschlicherweise "hauptkontonummer", richtig ist  "kontonummer"