### PR TITLE
PBU-6468 Darlehensdatenanfrage um Feld darlehensgeber erweitert

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -207,6 +207,8 @@ definitions:
           $ref: '#/definitions/Dokument'
       datenKontext:
         $ref: '#/definitions/DatenKontext'
+      darlehensgeber:
+        type: string
 
   DarlehensdatenAntwort:
     type: object


### PR DESCRIPTION
- Darlehensdatenanfrage um Feld darlehensgeber erweitert. Wird benötigt für Mapping der Darlehensart im Deuba-Prolongationsservice (Unterscheidung DSL/Deutsche Bank)